### PR TITLE
 Corrects RF gain dB <-> setpoint calculations

### DIFF
--- a/SoapyICR8600.hpp
+++ b/SoapyICR8600.hpp
@@ -135,13 +135,16 @@ public:
 
 	bool getGainMode(const int direction, const size_t channel) const;
 
-	//void setGain(const int direction, const size_t channel, const double value);
+	void setGain(const int direction, const size_t channel, const double value);
 
 	void setGain(const int direction, const size_t channel, const std::string &name, const double value);
 
 	double getGain(const int direction, const size_t channel, const std::string &name) const;
 
-	//SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
+	double getGain(const int direction, const size_t channel) const;
+
+	SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
+	
 	SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const;
 
 	/*******************************************************************

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -128,7 +128,7 @@ int SoapyICR8600::deactivateStream(SoapySDR::Stream *stream, const int flags, co
 }
 
 int SoapyICR8600::readStream(SoapySDR::Stream *stream, void * const *buffs, const size_t numElems, int &flags, long long &timeNs, const long timeoutUs) {
-	SoapySDR_logf(SOAPY_SDR_INFO, "SoapyICR8600::readStream: %d, flags: %d", numElems, flags);
+	SoapySDR_logf(SOAPY_SDR_TRACE, "SoapyICR8600::readStream: %d, flags: %d", numElems, flags);
 
 	ULONG cbRead = ICR8600ReadPipe(deviceData.WinusbHandle, bufferData, bufferLength);
 	int16_t *source = (int16_t *)bufferData;

--- a/WinUSBDevice.cpp
+++ b/WinUSBDevice.cpp
@@ -282,7 +282,7 @@ BOOL WriteToBulkEndpoint(WINUSB_INTERFACE_HANDLE hDeviceHandle, UCHAR ID, ULONG*
 	ULONG cbSent = 0;
 	bResult = WinUsb_WritePipe(hDeviceHandle, ID, send, cbSize, &cbSent, 0);
 	if (bResult) {
-		SoapySDR_logf(SOAPY_SDR_DEBUG, "WriteToBulkEndpoint: 0x%x: %d bytes, actual data transferred: %d", ID, cbSize, cbSent);
+		SoapySDR_logf(SOAPY_SDR_TRACE, "WriteToBulkEndpoint: 0x%x: %d bytes, actual data transferred: %d", ID, cbSize, cbSent);
 		*pcbWritten = cbSent;
 	}
 	else {
@@ -313,16 +313,16 @@ BOOL ReadFromBulkEndpoint(WINUSB_INTERFACE_HANDLE hDeviceHandle, UCHAR ID, ULONG
 		if (cbRead == 6) {
 			// FE FE E0 96 FB FD - OK
 			if (szBuffer[3] == 0x96 && szBuffer[4] == 0xFB)
-				SoapySDR_logf(SOAPY_SDR_DEBUG, "ReadFromBulkEndpoint: OK");
+				SoapySDR_logf(SOAPY_SDR_TRACE, "ReadFromBulkEndpoint: OK");
 			// FE FE E0 96 FA FD - Fail
 			else if (szBuffer[3] == 0x96 && szBuffer[4] == 0xFA)
 				SoapySDR_logf(SOAPY_SDR_ERROR, "ReadFromBulkEndpoint: Fail");
 			else
-				SoapySDR_logf(SOAPY_SDR_DEBUG, "ReadFromBulkEndpoint: output %Xh %Xh %Xh %Xh %Xh %Xh", szBuffer[0], szBuffer[1], szBuffer[2], szBuffer[3], szBuffer[4], szBuffer[5]);
+				SoapySDR_logf(SOAPY_SDR_TRACE, "ReadFromBulkEndpoint: output %Xh %Xh %Xh %Xh %Xh %Xh", szBuffer[0], szBuffer[1], szBuffer[2], szBuffer[3], szBuffer[4], szBuffer[5]);
 		}
 		else {
 			// printf("ReadFromBulkEndpoint: pipe 0x%x: size %d, actual data read: %d.\n", ID, cbSize, cbRead);
-			SoapySDR_logf(SOAPY_SDR_DEBUG, "ReadFromBulkEndpoint output (%d): %Xh %Xh %Xh %Xh  %Xh %Xh %Xh %Xh  %Xh %Xh %Xh %Xh  %Xh %Xh %Xh %Xh", cbRead, szBuffer[0], szBuffer[1], szBuffer[2], szBuffer[3], szBuffer[4], szBuffer[5], szBuffer[6], szBuffer[7],
+			SoapySDR_logf(SOAPY_SDR_TRACE, "ReadFromBulkEndpoint output (%d): %Xh %Xh %Xh %Xh  %Xh %Xh %Xh %Xh  %Xh %Xh %Xh %Xh  %Xh %Xh %Xh %Xh", cbRead, szBuffer[0], szBuffer[1], szBuffer[2], szBuffer[3], szBuffer[4], szBuffer[5], szBuffer[6], szBuffer[7],
 				szBuffer[8], szBuffer[9], szBuffer[10], szBuffer[11], szBuffer[12], szBuffer[13], szBuffer[14], szBuffer[15]);
 		}
 	}
@@ -352,7 +352,7 @@ ULONG ReadBufferFromBulkEndpoint(WINUSB_INTERFACE_HANDLE hDeviceHandle, UCHAR ID
 	ULONG cbRead = 0;
 	bResult = WinUsb_ReadPipe(hDeviceHandle, ID, szBuffer, cbSize, &cbRead, 0);
 	if (bResult) {
-		SoapySDR_logf(SOAPY_SDR_DEBUG, "ReadBufferFromBulkEndpoint: Read %d", cbRead);
+		SoapySDR_logf(SOAPY_SDR_TRACE, "ReadBufferFromBulkEndpoint: Read %d", cbRead);
 		return cbRead;
 	}
 	else {
@@ -384,7 +384,7 @@ BOOL GetAck(WINUSB_INTERFACE_HANDLE hDeviceHandle, UCHAR ID)
 		if (cbRead == 6) {
 			// FE FE E0 96 FB FD - OK
 			if (szBuffer[3] == 0x96 && szBuffer[4] == 0xFB)
-				SoapySDR_logf(SOAPY_SDR_DEBUG, "GetAck: Valid Command");
+				SoapySDR_logf(SOAPY_SDR_TRACE, "GetAck: Valid Command");
 			// FE FE E0 96 FA FD - Fail
 			else if (szBuffer[3] == 0x96 && szBuffer[4] == 0xFA)
 			{
@@ -526,6 +526,7 @@ BOOL ICR8600SetAntenna(WINUSB_INTERFACE_HANDLE hDeviceHandle, ULONG antennaIndex
 	SoapySDR_logf(SOAPY_SDR_TRACE, "ICR8600SetAntenna");
 	UCHAR set_ant[] = { 0xFE, 0xFE, 0x96, 0xE0, 0x12, (UCHAR)(antennaIndex & 0xff),  0xFD, 0xFF };
 	ULONG sent = 0;
+	SoapySDR_logf(SOAPY_SDR_DEBUG, "ICR8600SetAntenna: Index = %d", antennaIndex);
 	WriteToBulkEndpoint(hDeviceHandle, PIPE_CONTROL_ID, &sent, set_ant, sizeof(set_ant));
 	return GetAck(hDeviceHandle, PIPE_RESPONSE_ID);
 #else
@@ -564,7 +565,7 @@ ULONG ICR8600ReadPipe(WINUSB_INTERFACE_HANDLE hDeviceHandle, PUCHAR Buffer, ULON
 	ULONG cbRead = 0;
 	BOOL bResult = WinUsb_ReadPipe(hDeviceHandle, PIPE_IQ_ID, Buffer, BufferLength, &cbRead, 0);
 	if (bResult) {
-		SoapySDR_logf(SOAPY_SDR_DEBUG, "ICR8600ReadPipe: Read %d", cbRead);
+		SoapySDR_logf(SOAPY_SDR_TRACE, "ICR8600ReadPipe: Read %d", cbRead);
 		return cbRead;
 	}
 	else {
@@ -626,6 +627,7 @@ BOOL ICR8600SetAttenuator(WINUSB_INTERFACE_HANDLE hDeviceHandle, ULONG atten)
 	SoapySDR_logf(SOAPY_SDR_TRACE, "ICR8600SetAttenuator");
 	UCHAR set_atten[] = { 0xFE, 0xFE, 0x96, 0xE0,  0x11, decToBcd(atten), 0xFD, 0xFF };
 	ULONG sent = 0;
+	SoapySDR_logf(SOAPY_SDR_TRACE, "ICR8600SetAttenuator: Attenuator = %d", atten);
 	WriteToBulkEndpoint(hDeviceHandle, PIPE_CONTROL_ID, &sent, set_atten, sizeof(set_atten));
 	return GetAck(hDeviceHandle, PIPE_RESPONSE_ID);
 #else

--- a/py_test.py
+++ b/py_test.py
@@ -66,9 +66,9 @@ print("Attenuator Readback = " + str(sdr.getGain(SOAPY_SDR_RX, 0, "ATTENUATOR"))
 
 sdr.setGain(SOAPY_SDR_RX, 0, "RF", 0.0)
 print("RF Gain Readback = " + str(sdr.getGain(SOAPY_SDR_RX, 0, "RF")))
-sdr.setGain(SOAPY_SDR_RX, 0, "RF", 128.0)
+sdr.setGain(SOAPY_SDR_RX, 0, "RF", -32.0)
 print("RF Gain Readback = " + str(sdr.getGain(SOAPY_SDR_RX, 0, "RF")))
-sdr.setGain(SOAPY_SDR_RX, 0, "RF", 255.0)
+sdr.setGain(SOAPY_SDR_RX, 0, "RF", -63.75)
 print("RF Gain Readback = " + str(sdr.getGain(SOAPY_SDR_RX, 0, "RF")))
 
 #setup a stream (complex floats)


### PR DESCRIPTION
**Corrects RF gain dB <-> setpoint calculations**

The RF gain on the R8600 takes a value between 0 and 255.  After some
searching through the manual, the exact meaning of this value has not
been found.  It is referred to as both RF Gain and Sensitivity.

Rough measurements were performed to determine how this value might
relate to radio gain in dB.  A reasonable "guess" is max gain = 0dB
(setpoint of 255), and min gain (setpoint of 0) is -63.75dB

These conversions are now implemented in the driver.

This commit also tweaks some of the INFO, DEBUG, and TRACE messages.

~~NOTE:  The driver currently does not work properly with Quisk.  Once
actual gain settings were able to be set (via one of the earlier commits),
Quisk stopped working.  It appears that Quisk is not handling the multiple
gain options properly, and/or this driver needs to implement its own
function to handle a "global" gain setting.  This is a heads up for anyone
trying to use Quisk or other programs that don't allow individual setting of
gain parameters.~~

**Implements preferred method of global gain setting**

The strategy for a single global gain value is:

If the desired gain > 0, turn on the pre-amp (+14dB),
otherwise, turn it off (+0dB)

Then, check to see if any of the attenuator values make sense
(-30dB, -20dB, -10dB, or -0dB)

Finally, make up any remaining difference using the RF Gain
(-63.75dB to 0dB)

getGainRange for overall gain is now valid.

NOTE: This commit partially corrects the issue with Quisk.  Quisk is
still not using the correct gain range (it seems to insist on 0dB to
32dB). At least now if gain is set in the 0dB to 14dB range, this
driver will work.



 