### PR TITLE
Handle antenna selection based on frequency

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -117,18 +117,29 @@ void SoapyICR8600::setAntenna(const int direction, const size_t channel, const s
 		throw std::runtime_error("setAntena failed: RTL-SDR only supports RX");
 	}
 
-	if (name == "ANT 1") {
-		antennaIndex = 0;
-		ICR8600SetAntenna(deviceData.WinusbHandle, 0);
+	// On the R8600,
+	// Antenna commands only function in the HF region
+	// ANT 1 is automatically selected outside the HF region
+	if (centerFrequency < 30000000) {
+		if (name == "ANT 1") {
+			antennaIndex = 0;
+			ICR8600SetAntenna(deviceData.WinusbHandle, 0);
+		}
+		else if (name == "ANT 2") {
+			antennaIndex = 1;
+			ICR8600SetAntenna(deviceData.WinusbHandle, 1);
+		}
+		else if (name == "ANT 3") {
+			antennaIndex = 2;
+			ICR8600SetAntenna(deviceData.WinusbHandle, 2);
+		}		
 	}
-	else if (name == "ANT 2") {
-		antennaIndex = 1;
-		ICR8600SetAntenna(deviceData.WinusbHandle, 1);
+	else {
+		if (name != "ANT 1") {
+			SoapySDR_logf(SOAPY_SDR_ERROR, "setAntenna %s invalid for frequency %d", name, centerFrequency);
+		}
 	}
-	else if (name == "ANT 3") {
-		antennaIndex = 2;
-		ICR8600SetAntenna(deviceData.WinusbHandle, 2);
-	}
+
 }
 
 std::string SoapyICR8600::getAntenna(const int direction, const size_t channel) const
@@ -136,7 +147,13 @@ std::string SoapyICR8600::getAntenna(const int direction, const size_t channel) 
 	ULONG antennaIndex;
 	std::string antenna = "";
 
-	if (ICR8600GetAntenna(deviceData.WinusbHandle, &antennaIndex))
+	// On the R8600,
+	// Antenna commands only function in the HF region
+	// ANT 1 is automatically selected outside the HF region
+	if (centerFrequency >= 30000000) {
+		antenna = "ANT 1";		
+	}
+	else if (ICR8600GetAntenna(deviceData.WinusbHandle, &antennaIndex))
 	{
 		switch(antennaIndex)
 		{

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -112,6 +112,8 @@ std::vector<std::string> SoapyICR8600::listAntennas(const int direction, const s
 
 void SoapyICR8600::setAntenna(const int direction, const size_t channel, const std::string &name)
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	if (direction != SOAPY_SDR_RX)
 	{
 		throw std::runtime_error("setAntena failed: RTL-SDR only supports RX");
@@ -144,6 +146,8 @@ void SoapyICR8600::setAntenna(const int direction, const size_t channel, const s
 
 std::string SoapyICR8600::getAntenna(const int direction, const size_t channel) const
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	ULONG antennaIndex;
 	std::string antenna = "";
 
@@ -234,6 +238,8 @@ bool SoapyICR8600::getGainMode(const int direction, const size_t channel) const
 
 void SoapyICR8600::setGain(const int direction, const size_t channel, const double value)
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	//set the overall gain by distributing it across available gain elements
 
 	// RF Gain -63.75dB to 0dB
@@ -297,6 +303,8 @@ void SoapyICR8600::setGain(const int direction, const size_t channel, const doub
 
 void SoapyICR8600::setGain(const int direction, const size_t channel, const std::string &name, const double value)
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	//    SoapySDR_logf(SOAPY_SDR_DEBUG, "Setting RTL-SDR IF Gain for stage %d: %f", stage, IFGain[stage - 1]);
 
 	if (name == "RF")
@@ -350,6 +358,8 @@ double SoapyICR8600::getGain(const int direction, const size_t channel) const
 
 double SoapyICR8600::getGain(const int direction, const size_t channel, const std::string &name) const
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	ULONG set;
 	double gain;
 
@@ -454,6 +464,8 @@ SoapySDR::Range SoapyICR8600::getGainRange(const int direction, const size_t cha
 
 void SoapyICR8600::setFrequency(const int direction, const size_t channel, const std::string &name, const double frequency, const SoapySDR::Kwargs &args)
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	if (name == "RF")
 	{
 		centerFrequency = (ULONG)frequency;
@@ -517,6 +529,8 @@ SoapySDR::ArgInfoList SoapyICR8600::getFrequencyArgsInfo(const int direction, co
 
 void SoapyICR8600::setSampleRate(const int direction, const size_t channel, const double rate)
 {
+	std::lock_guard<std::mutex> lock(_device_mutex);
+
 	sampleRate = (ULONG)rate;
 	SoapySDR_logf(SOAPY_SDR_INFO, "Setting sample rate: %d", sampleRate);
 	ICR8600SetSampleRate(deviceData.WinusbHandle, sampleRate);

--- a/SoapyICR8600.hpp
+++ b/SoapyICR8600.hpp
@@ -200,4 +200,10 @@ private:
 	int antennaIndex;
 	size_t bufferLength;
 	unsigned char *bufferData;
+
+	// mutex protection because we need to be thread safe
+	mutable std::mutex	_device_mutex;
+	std::mutex	_buf_mutex;
+
 };
+

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -95,10 +95,10 @@ SoapySDR::Stream *SoapyICR8600::setupStream(const int direction, const std::stri
 	bufferData = (unsigned char*)malloc(2 * bufferLength * sizeof(unsigned char));
 
 	//Set parameters
-	SoapySDR_logf(SOAPY_SDR_INFO, "ICR8600SetFrequency: %d", centerFrequency);
-	ICR8600SetFrequency(deviceData.WinusbHandle, centerFrequency);
-	SoapySDR_logf(SOAPY_SDR_INFO, "ICR8600SetSampleRate: %d", sampleRate);
-	ICR8600SetSampleRate(deviceData.WinusbHandle, sampleRate);
+	//SoapySDR_logf(SOAPY_SDR_INFO, "ICR8600SetFrequency: %d", centerFrequency);
+	//ICR8600SetFrequency(deviceData.WinusbHandle, centerFrequency);
+	//SoapySDR_logf(SOAPY_SDR_INFO, "ICR8600SetSampleRate: %d", sampleRate);
+	//ICR8600SetSampleRate(deviceData.WinusbHandle, sampleRate);
 
 	return (SoapySDR::Stream *) this;
 }
@@ -128,6 +128,8 @@ int SoapyICR8600::deactivateStream(SoapySDR::Stream *stream, const int flags, co
 }
 
 int SoapyICR8600::readStream(SoapySDR::Stream *stream, void * const *buffs, const size_t numElems, int &flags, long long &timeNs, const long timeoutUs) {
+	std::unique_lock<std::mutex> lock(_buf_mutex);
+	
 	SoapySDR_logf(SOAPY_SDR_TRACE, "SoapyICR8600::readStream: %d, flags: %d", numElems, flags);
 
 	ULONG cbRead = ICR8600ReadPipe(deviceData.WinusbHandle, bufferData, bufferLength);

--- a/py_test.py
+++ b/py_test.py
@@ -44,6 +44,15 @@ for antenna in antennas:
 	sdr.setAntenna(SOAPY_SDR_RX, 0, antenna)
 	print("\tAntenna Readback = " + sdr.getAntenna(SOAPY_SDR_RX, 0))
 
+# set outside the HF band
+sdr.setFrequency(SOAPY_SDR_RX, 0, 100000000)
+# antennas 
+antennas = sdr.listAntennas(SOAPY_SDR_RX, 0)
+print("Antennas:", antennas)
+for antenna in antennas:
+	sdr.setAntenna(SOAPY_SDR_RX, 0, antenna)
+	print("\tAntenna Readback = " + sdr.getAntenna(SOAPY_SDR_RX, 0))
+
 # exercise gains
 gains = sdr.listGains(SOAPY_SDR_RX, 0)
 print("Gains:", gains)


### PR DESCRIPTION
The R8600 has three antenna ports, ANT 1, ANT 2, and ANT 3
When operating in HF mode (frequency < 30MHz), any antenna may be selected,
and the antenna control commands are accepted by the radio.

Outside of the HF range, ANT 1 is automatically selected by the
radio and any antenna control command is rejected.

The driver has been modified to better match the radio's operation:

When the frequency has been set less than 30MHz, getAntenna() and setAntenna() work as expected.

When greater than or equal to 30MHz, getAntenna() always returns ANT 1,
and setAntenna() will log an error if the desired antenna is not ANT 1.
Additionally, neither function actually sends a control command to the radio.

One outstanding question is if listAntennas() should modify its return based on
the frequency selected. Applications may not expect the antenna list to be a
dynamic item. At this point, listAntennas() always returns the three options.